### PR TITLE
feat: Polyfill process object in Vite config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,4 +7,7 @@ export default defineConfig({
   optimizeDeps: {
     exclude: ['lucide-react'],
   },
+  define: {
+    'process.env': {},
+  },
 });


### PR DESCRIPTION
Adds a `define` property to `vite.config.ts` to polyfill `process.env`. This resolves the "Uncaught ReferenceError: process is not defined" error that occurs when using Node.js-dependent libraries in the browser.